### PR TITLE
Add Binder link to README, update supported platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ Point cloud processing slides
 
 Static presentation available [here](https://www.rockestate.be/point-cloud-processing/presentation/)
 
-Notebook available [here](https://github.com/rockestate/point-cloud-processing/blob/master/notebooks/point-cloud-processing.ipynb)
+Static notebook available [here](https://github.com/rockestate/point-cloud-processing/blob/master/notebooks/point-cloud-processing.ipynb) or try running it live in the browser with [Binder](https://mybinder.org/v2/gh/rockestate/point-cloud-processing/master)!
 
 ## Initial setup
 
-Will work on linux, may work on macOS. [Get in touch](mailto:hello@rockestate.be) if you'd like to give us a hand to make it run on Windows.
+Will work on Linux, macOS, and Windows.
 
 Make sure you have `git` and [`conda`](https://conda.io/miniconda.html) installed and on your path.
 


### PR DESCRIPTION
Users can run this in the browser through the provided Binder link.

Your notebooks and environment.yml work fine for me on macOS and Windows, likely due to the recent switch to the conda-forge PDAL packaging.